### PR TITLE
Create .gitattributes to prevent develop files into the release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore
+
+docs export-ignore
+.env export-ignore
+.php-cs-fixer.cache export-ignore
+.php_cs.cache export-ignore
+.stoplight.json export-ignore
+README.MD export-ignore
+docker-compose.yml  export-ignore
+toc.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,5 @@ docs export-ignore
 .php-cs-fixer.cache export-ignore
 .php_cs.cache export-ignore
 .stoplight.json export-ignore
-README.MD export-ignore
 docker-compose.yml  export-ignore
 toc.json export-ignore


### PR DESCRIPTION
Develop files are present in the release sent to customer.
It is a better practice to remove them.